### PR TITLE
Feature/register 이미지 업로드 코드 수정 및 글자수 제한 조정

### DIFF
--- a/apps/web/constants/env.ts
+++ b/apps/web/constants/env.ts
@@ -3,3 +3,5 @@ export const FE_URL = process.env.NEXT_PUBLIC_FE_URL as string;
 
 export const REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY as string;
 export const KAKAO_APP_KEY = process.env.NEXT_PUBLIC_KAKAO_APP_KEY as string;
+
+export const IMAGE_BB_API_KEY = process.env.NEXT_PUBLIC_IMAGE_BB_API_KEY as string;

--- a/apps/web/containers/Register/index.module.scss
+++ b/apps/web/containers/Register/index.module.scss
@@ -34,7 +34,7 @@
     input {
       width: 75%;
       padding: 5px;
-      font-size: var(--font-size-m);
+      font-size: var(--font-size-s);
       @include m.borderStyles($radius_size: --border-radius-xs);
     }
 
@@ -136,5 +136,14 @@
     height: 25px;
     font-size: var(--font-size-xs);
     border-radius: 1rem;
+  }
+
+  .resultH3 {
+    width: 100%;
+    padding: 3px;
+    text-align: center;
+    margin-top: 10px;
+    background-color: var(--color-bg-ivory);
+    border-radius: var(--border-radius-s);
   }
 }

--- a/apps/web/containers/Register/index.tsx
+++ b/apps/web/containers/Register/index.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, useState } from 'react';
 
 import { CONTENT_TYPE } from '@/constants';
 import { apiBe, getHeaders } from '@/services';
+import { uploadToImageBB } from '@/services/upload';
 import { ContentType, IQuestion } from '@/types';
 
 import styles from './index.module.scss';
@@ -13,7 +14,7 @@ import Button from '@/components/Buttons/Button';
 interface ContentData {
   title: string;
   content: string;
-  imageUrls: { index: number; imageUrl: File | null }[];
+  imageUrl: string;
   type: ContentType;
 }
 
@@ -21,6 +22,7 @@ interface ResultData {
   result: string;
   title: string;
   content: string;
+  imageUrl: string;
 }
 
 const SCORE_OPTIONS = [-1, 1];
@@ -47,6 +49,7 @@ const initialResults = MBTI_RESULT_TYPE.map((type) => ({
   result: type,
   title: '',
   content: '',
+  imageUrl: '',
 }));
 
 const MBTI_QUESTIONS_TYPE = [
@@ -57,11 +60,11 @@ const MBTI_QUESTIONS_TYPE = [
 ];
 
 export default function Register() {
-  const [data, setData] = useState<ContentData>({
+  const [content, setContent] = useState<ContentData>({
     type: 'MBTI',
     title: '',
     content: '',
-    imageUrls: [],
+    imageUrl: '',
   });
 
   const [questions, setQuestions] = useState<IQuestion[]>([
@@ -84,14 +87,15 @@ export default function Register() {
   const [results, setResults] = useState<ResultData[]>(initialResults);
 
   const handleInputChange = (value: string | number, field: string) => {
-    setData((prev) => ({ ...prev, [field]: value }));
+    setContent((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>, index?: number) => {
     const file = e.target.files?.[0] ?? null;
-    const updateImageUrls = [...data.imageUrls];
-    updateImageUrls[index] = { index, imageUrl: file };
-    setData((prevData) => ({ ...prevData, imageUrls: updateImageUrls }));
+    const imageUrl = await uploadToImageBB(file!);
+
+    if (index === -1) setContent((prev) => ({ ...prev, imageUrl }));
+    setResults(results.map((r, i) => (i === index ? { ...r, imageUrl } : r)));
   };
 
   const handleQuestionChange = (index: number, field: string, value: string | number) => {
@@ -169,7 +173,6 @@ export default function Register() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const formData = new FormData();
     const headers = getHeaders();
 
     const checkOddCountIndices = () => {
@@ -186,31 +189,24 @@ export default function Register() {
       return oddIndices.length === 4;
     };
 
-    if (data.type === 'MBTI' && questions.length < 4 && results.length !== 16)
+    if (content.type === 'MBTI' && questions.length < 4 && results.length !== 16)
       return alert('MBTI의 질문은 최소 4개 이상, 결과는 16개로 작성해주세요!');
 
     if (!checkOddCountIndices()) {
       return alert('각 질문의 점수의 합이 0이 되지 않도록 홀 수로 작성해 주세요!');
     }
 
-    formData.append('type', data.type);
-    formData.append('title', data.title);
-    formData.append('content', data.content);
-
-    data!.imageUrls.forEach((image: { index: number; imageUrl: File | null }) => {
-      if (image.imageUrl instanceof File) {
-        formData.append(`imageUrls`, image.imageUrl);
-      }
-    });
-
-    formData.append('questions', JSON.stringify(questions));
-    formData.append('results', JSON.stringify(results));
+    const contentData = {
+      ...content,
+      questions,
+      results,
+    };
 
     try {
-      const response = await apiBe.post('/v1/contents', formData, {
+      const response = await apiBe.post('/v1/contents', contentData, {
         headers: {
           ...headers,
-          'Content-Type': 'multipart/form-data',
+          'Content-Type': 'application/json',
         },
       });
 
@@ -221,12 +217,12 @@ export default function Register() {
   };
 
   return (
-    <form className={styles.formWrap} onSubmit={handleSubmit} encType="multipart/form-data">
+    <form className={styles.formWrap} onSubmit={handleSubmit}>
       <label>
         <p>카테고리</p>
         <select
           name="type"
-          defaultValue={data.type}
+          defaultValue={content.type}
           onChange={(e) => handleInputChange(e.target.value, 'type')}
         >
           {CONTENT_TYPE.map((option) => (
@@ -241,7 +237,7 @@ export default function Register() {
         <input
           type="text"
           name="title"
-          value={data.title}
+          value={content.title}
           onChange={(e) => handleInputChange(e.target.value, 'title')}
           required
           maxLength={100}
@@ -252,11 +248,11 @@ export default function Register() {
         <p>설명</p>
         <textarea
           name="content"
-          value={data.content}
+          value={content.content}
           onChange={(e) => handleInputChange(e.target.value, 'content')}
           required
           rows={4}
-          maxLength={100}
+          maxLength={500}
         />
       </label>
 
@@ -267,7 +263,7 @@ export default function Register() {
           name="image"
           className={styles.inputFile}
           accept="image/*"
-          onChange={(e) => handleFileChange(e, 0)}
+          onChange={(e) => handleFileChange(e, -1)}
           required
         />
       </label>
@@ -277,7 +273,7 @@ export default function Register() {
 
         {questions.map((question, i) => (
           <div key={`question + ${i}`} className={cx(styles.labelBox, styles.questionLabelBox)}>
-            {data.type === 'MBTI' && (
+            {content.type === 'MBTI' && (
               <label>
                 <p>질문 타입</p>
                 <select
@@ -303,7 +299,7 @@ export default function Register() {
                 value={question.question}
                 onChange={(e) => handleQuestionChange(i, 'question', e.target.value)}
                 required
-                maxLength={100}
+                maxLength={200}
               />
             </label>
 
@@ -340,7 +336,7 @@ export default function Register() {
                           required
                         />
 
-                        {data.type === 'MBTI' ? (
+                        {content.type === 'MBTI' ? (
                           <span>{MBTI_QUESTIONS_TYPE[question.index]![index]}</span>
                         ) : (
                           <span>score</span>
@@ -413,7 +409,7 @@ export default function Register() {
                 required
                 rows={4}
                 cols={50}
-                maxLength={100}
+                maxLength={500}
               />
             </label>
             <label>
@@ -423,7 +419,7 @@ export default function Register() {
                 name="resultImage"
                 accept="image/*"
                 className={styles.inputFile}
-                onChange={(e) => handleFileChange(e, i + 1)}
+                onChange={(e) => handleFileChange(e, i)}
                 required
               />
             </label>

--- a/apps/web/containers/Register/index.tsx
+++ b/apps/web/containers/Register/index.tsx
@@ -42,6 +42,13 @@ const MBTI_RESULT_TYPE = [
   'ISTJ',
   'ISTP',
 ];
+
+const initialResults = MBTI_RESULT_TYPE.map((type) => ({
+  result: type,
+  title: '',
+  content: '',
+}));
+
 const MBTI_QUESTIONS_TYPE = [
   ['I', 'E'],
   ['S', 'N'],
@@ -74,13 +81,7 @@ export default function Register() {
     },
   ]);
 
-  const [results, setResults] = useState<ResultData[]>([
-    {
-      result: '',
-      title: '',
-      content: '',
-    },
-  ]);
+  const [results, setResults] = useState<ResultData[]>(initialResults);
 
   const handleInputChange = (value: string | number, field: string) => {
     setData((prev) => ({ ...prev, [field]: value }));
@@ -118,7 +119,6 @@ export default function Register() {
   const handleResultChange = (index: number, field: string, value: string) => {
     setResults(results.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
   };
-  const getSelectedValues = () => results.map((result) => result.result);
 
   const addQuestion = () => {
     const newQuestion: IQuestion = {
@@ -148,16 +148,6 @@ export default function Register() {
     });
   };
 
-  const addResult = () =>
-    setResults([
-      ...results,
-      {
-        result: '',
-        title: '',
-        content: '',
-      },
-    ]);
-
   const removeQuestion = (index: number) => {
     setQuestions((prev) => prev.filter((_, i) => i !== index));
   };
@@ -174,10 +164,6 @@ export default function Register() {
         return question;
       }),
     );
-  };
-
-  const removeResult = (index: number) => {
-    setResults((prev) => prev.filter((_, i) => i !== index));
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -313,7 +299,7 @@ export default function Register() {
               <p>질문 {i + 1}</p>
               <textarea
                 name={`question-${i}`}
-                rows={2}
+                rows={4}
                 value={question.question}
                 onChange={(e) => handleQuestionChange(i, 'question', e.target.value)}
                 required
@@ -366,8 +352,7 @@ export default function Register() {
 
                 <label>
                   <p>대답</p>
-                  <input
-                    type="text"
+                  <textarea
                     name={`answer-${i}-${j}`}
                     value={answer.text}
                     onChange={(e) => handleAnswerChange(i, j, 'text', e.target.value)}
@@ -407,39 +392,9 @@ export default function Register() {
         <h3>Results ( total : {results.length} )</h3>
         {results.map((result, i) => (
           <div key={i} className={styles.labelBox}>
+            <h3 className={styles.resultH3}>{result.result}</h3>
             <label>
-              <p>결과 타입</p>
-              {data.type === 'MBTI' ? (
-                <select
-                  name="result"
-                  value={result.result}
-                  className="yellow"
-                  onChange={(e) => handleResultChange(i, 'result', e.target.value)}
-                >
-                  <option value="">결과를 선택하세요.</option>
-                  {MBTI_RESULT_TYPE.map((resultOption) => (
-                    <option
-                      key={resultOption}
-                      value={resultOption}
-                      disabled={getSelectedValues().includes(resultOption)}
-                    >
-                      {resultOption}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  type="text"
-                  name="result"
-                  value={result.result}
-                  className="yellow"
-                  onChange={(e) => handleResultChange(i, 'result', e.target.value)}
-                  required
-                />
-              )}
-            </label>
-            <label>
-              <p>결과 제목</p>
+              <p>{result.result} 제목</p>
               <input
                 type="text"
                 name="resultTitle"
@@ -450,7 +405,7 @@ export default function Register() {
               />
             </label>
             <label>
-              <p>결과 내용</p>
+              <p>{result.result} 내용</p>
               <textarea
                 name="resultContent"
                 value={result.content}
@@ -462,7 +417,7 @@ export default function Register() {
               />
             </label>
             <label>
-              <p>결과 이미지</p>
+              <p>{result.result} 이미지</p>
               <input
                 type="file"
                 name="resultImage"
@@ -472,20 +427,8 @@ export default function Register() {
                 required
               />
             </label>
-            {results.length > 1 && (
-              <button
-                type="button"
-                className={cx('blue', styles.miniBtn)}
-                onClick={() => removeResult(i)}
-              >
-                – Results
-              </button>
-            )}
           </div>
         ))}
-        <button type="button" className={cx('deepPink', styles.addBtn)} onClick={addResult}>
-          + Results
-        </button>
       </div>
       <Button type="submit" color="green" text="완료" />
     </form>

--- a/apps/web/services/kakao.ts
+++ b/apps/web/services/kakao.ts
@@ -22,7 +22,7 @@ export const setKakaoLogin = () => {
 
 export const kakaoLoginAPI = async (code: string) => {
   const res = await apiBe(`/oauth2/kakao/login`, {
-    params: { code },
+    params: { code, url: FE_URL + '/login/kakao' },
   });
 
   return res;

--- a/apps/web/services/upload.ts
+++ b/apps/web/services/upload.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+import { IMAGE_BB_API_KEY } from '../constants';
+
+export const uploadToImageBB = async (imageFile: File): Promise<string> => {
+  const data = new FormData();
+  data.append('image', imageFile);
+  data.append('key', IMAGE_BB_API_KEY);
+
+  const config = {
+    method: 'post',
+    maxBodyLength: Infinity,
+    url: 'https://api.imgbb.com/1/upload',
+    headers: {
+      'content-type': 'multipart/form-data',
+    },
+    data: data,
+  };
+
+  try {
+    const response = await axios.request(config);
+    return response.data.data.url;
+  } catch (_error) {
+    throw new Error('Image upload failed');
+  }
+};


### PR DESCRIPTION
UX / UI 수정

<img src="https://github.com/user-attachments/assets/8c1d8354-3651-4bf1-a8a8-45c9ca935536" width='200px' />
<img src="https://github.com/user-attachments/assets/b46d08fc-0e42-41e1-a8af-b1a70ab8a14e" width='200px' />


- 결과창 16개 미리 생성 : 셀렉터를 통해 클릭하는 방식을 직접 써보니... 불편해서 변경
- input -> textarea : 설명이나 긴글의 경우 줄바꿈이 필요하다고 판단함..(이것 역시 써보니..)

- 이미지 전송 방법 변경
  - 기존 : 직접 파일을 배열로하여 서버로 전송. 서버에서 이미지를 url로 변경하여 저장하는 방법
  - 변경 : 클라이언트에서 직접 이미지를 url로 변경하여, 서버로 전송

- kakao login : 클라이언트 url을 api로 kakao 응답 code와 함께 전송
  - 개발 환경 / 서비스 웹에서 모두 사용하기 위함. 개발 환경의경우 테스트 서버가 따로 없는 관계로 로컬주소와 웹주소 두개를 다써야 해서 추가함