### PR TITLE
Feature/modal 개선 (배경 스크롤 및 닫기) 및 스타일 수정

### DIFF
--- a/apps/web/components/ModalContent/index.module.scss
+++ b/apps/web/components/ModalContent/index.module.scss
@@ -1,5 +1,7 @@
 @use 'styles/mixins' as m;
 
+$width: 320px;
+
 .wrap {
   max-width: var(--max-width);
   min-width: var(--min-width);
@@ -14,10 +16,10 @@
   overflow: hidden;
 
   .modalContainer {
-    width: 250px;
+    width: $width;
     position: absolute;
     top: 35%;
-    left: calc(50% - 125px);
+    left: calc(50% - ($width/2));
 
     border-radius: 0.5rem;
     background-color: var(--color-bg-ivory);
@@ -47,7 +49,8 @@
           gap: 40px;
 
           button {
-            padding: 5px 12px;
+            padding: 7px 15px;
+            color: var(--font-color);
             @include m.borderStyles();
           }
           .checkBtn {

--- a/apps/web/components/ModalContent/index.tsx
+++ b/apps/web/components/ModalContent/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import styles from './index.module.scss';
 import WindowStyle from '../WindowStyles';
@@ -22,6 +22,8 @@ const ModalContent = ({
   onClickCheckBtn,
   onClickCancelBtn,
 }: Props) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -34,23 +36,38 @@ const ModalContent = ({
     [onClickCancelBtn],
   );
 
+  const handleClickModalOutside = useCallback(
+    (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClickCancelBtn();
+      }
+    },
+    [onClickCancelBtn],
+  );
+
   useEffect(() => {
     if (showModal) {
       document.addEventListener('keydown', handleKeyDown);
+      document.addEventListener('mousedown', handleClickModalOutside);
+      document.documentElement.classList.add('mobileCoverOpen');
     } else {
       document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleClickModalOutside);
+      document.documentElement.classList.remove('mobileCoverOpen');
     }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('mousedown', handleClickModalOutside);
     };
   }, [showModal, handleKeyDown]);
 
   if (!showModal) return null;
+
   return (
     showModal && (
       <div className={styles.wrap}>
-        <div className={styles.modalContainer}>
+        <div className={styles.modalContainer} ref={modalRef}>
           <div className={styles.modalWrap}>
             <button className={styles.topCloseBtn} onClick={onClickCancelBtn} />
             <WindowStyle title={title} color="blue">

--- a/apps/web/components/WindowStyles/index.module.scss
+++ b/apps/web/components/WindowStyles/index.module.scss
@@ -15,10 +15,10 @@
       gap: 6px;
 
       h3 {
-        font-size: var(--font-size-m);
+        font-size: 0.9rem;
       }
       p {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
       }
     }
 


### PR DESCRIPTION
Modal
- 외부 클릭시 닫기
- 배경 스크롤바 막기
  - 모달이 활성화 되면 최상단에 'mobileCoverOpen' class name 생성, 닫히면 remove하도록 함 (side nav bar와 동일)
  ``` css
  html.mobileCoverOpen {
    overflow-y: hidden;
    -webkit-text-size-adjust: none;
  }
  ```

- 모달 가로길이 및 타이틀 폰트 사이즈 조절 
  
![image](https://github.com/user-attachments/assets/e917e530-8267-472b-9b7d-06baac99c27c)
