### PR TITLE
feat : likeContent 컴포넌트 추가 및 useDebounce 훅 추가

### DIFF
--- a/apps/web/components/ButtonBox/IconButtons/index.tsx
+++ b/apps/web/components/ButtonBox/IconButtons/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { PATHS } from '@/constants';
 // import { postShareAPI } from '@/services/contents';
+import useDebounce from '@/hooks/useDebounce';
 import { getLikeAPI, postLikeAPI } from '@/services/like';
 import { IContent, IResult } from '@/types';
 import { decodeToken_csr } from '@/utils';
@@ -53,6 +54,8 @@ export const LikeButton = ({ contentId }: Props) => {
     },
   });
 
+  const debouncedPostLike = useDebounce(postLike, 500);
+
   const handleModal = () => {
     setShowModal(!showModal);
   };
@@ -63,8 +66,11 @@ export const LikeButton = ({ contentId }: Props) => {
   };
 
   const handlePostLike = () => {
-    if (isLogin) handleModal();
-    else postLike();
+    if (isLogin) {
+      handleModal();
+    } else {
+      debouncedPostLike();
+    }
   };
 
   useEffect(() => {

--- a/apps/web/components/Items/LikeContentItem/index.module.scss
+++ b/apps/web/components/Items/LikeContentItem/index.module.scss
@@ -1,0 +1,47 @@
+@use 'styles/mixins' as m;
+
+$icon-size: 2.5rem;
+
+.wrap {
+  width: 100%;
+  border-bottom: 1px dashed var(--color-gray-d);
+  padding-bottom: 8px;
+  @include m.flexbox();
+  gap: 20px;
+
+  .linkWrap {
+    width: 100%;
+    @include m.flexbox();
+    gap: 20px;
+
+    .imgWrap {
+      width: 40%;
+      height: 50px;
+
+      position: relative;
+      overflow: hidden;
+
+      @include m.flexboxColumn();
+      margin-bottom: 3px;
+
+      .image {
+        object-fit: cover;
+        object-position: center;
+      }
+    }
+
+    .title {
+      font-size: 1rem;
+      @include m.textEllipsis();
+      font-weight: var(--font-weight-bold);
+    }
+  }
+
+  .likeIcon {
+    width: 1.7rem;
+  }
+
+  .iconRed {
+    filter: invert(41%) sepia(77%) saturate(3177%) hue-rotate(338deg) brightness(85%) contrast(103%);
+  }
+}

--- a/apps/web/components/Items/LikeContentItem/index.tsx
+++ b/apps/web/components/Items/LikeContentItem/index.tsx
@@ -1,0 +1,61 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import cx from 'classnames';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+
+import { PATHS, SIMPANG_ALT } from '@/constants';
+import useDebounce from '@/hooks/useDebounce';
+import { postLikeAPI } from '@/services';
+import { IContent } from '@/types';
+
+import styles from './index.module.scss';
+
+const LikeContentItem = ({ _id, imageUrl, title }: Partial<IContent>) => {
+  const [likeState, setLikeState] = useState<boolean>(true);
+
+  const queryClient = useQueryClient();
+
+  const { mutate: postLike } = useMutation({
+    mutationFn: () => postLikeAPI(_id!),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['like'] });
+      setLikeState(data.liked);
+    },
+  });
+
+  const debouncedPostLike = useDebounce(postLike, 500);
+
+  const handlePostLike = () => {
+    debouncedPostLike();
+  };
+
+  return (
+    <div className={styles.wrap}>
+      <Link href={`${PATHS.CONTENTS.BASE}/${_id}`} className={styles.linkWrap}>
+        <div className={cx(styles.imgWrap, 'back_shadow')}>
+          <Image
+            src={imageUrl!}
+            priority
+            alt={SIMPANG_ALT}
+            fill
+            sizes="100%"
+            placeholder="blur"
+            blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+            className={styles.image}
+          />
+        </div>
+        <p className={styles.title}>{title}</p>
+      </Link>
+      <button onClick={handlePostLike}>
+        <img
+          className={cx(styles.likeIcon, likeState ? styles.iconRed : '')}
+          src="/svgs/like_mini.svg"
+          alt={SIMPANG_ALT}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default LikeContentItem;

--- a/apps/web/containers/Mypage/ContentList/index.tsx
+++ b/apps/web/containers/Mypage/ContentList/index.tsx
@@ -14,6 +14,7 @@ type ContentListProps<T> = {
   queryFn: (params: PageParams) => Promise<GetPageData<T>>;
   itemComponent: React.ComponentType<T>;
   contentIdKey: string;
+  size?: number;
 };
 
 const ContentList = <T,>({
@@ -21,12 +22,13 @@ const ContentList = <T,>({
   queryFn,
   itemComponent: ItemComponent,
   contentIdKey,
+  size,
 }: ContentListProps<T>) => {
   const [page, setPage] = useState(1);
 
   const { data, error, status } = useQuery({
-    queryKey: [...queryKey, page],
-    queryFn: () => queryFn({ page, size: 5, sort: 'desc' }),
+    queryKey: [...queryKey, page, size],
+    queryFn: () => queryFn({ page, size: size || 5, sort: 'desc' }),
     placeholderData: keepPreviousData,
   });
 

--- a/apps/web/containers/Mypage/index.tsx
+++ b/apps/web/containers/Mypage/index.tsx
@@ -13,7 +13,7 @@ import ContentList from './ContentList';
 import styles from './index.module.scss';
 import { FloatBtnBox } from '@/components/ButtonBox/FloatBtnBox';
 import Button from '@/components/Buttons/Button';
-import ContentItem from '@/components/Items/ContentItem';
+import LikeContentItem from '@/components/Items/LikeContentItem';
 import ResultItem from '@/components/Items/ResultItem';
 import { Loading } from '@/components/Loading';
 import ModalContent from '@/components/ModalContent';
@@ -113,8 +113,9 @@ export default function Mypage() {
               <ContentList
                 queryKey={['likeContents']}
                 queryFn={getLikeContentsAPI}
-                itemComponent={ContentItem}
+                itemComponent={LikeContentItem}
                 contentIdKey="contentId"
+                size={10}
               />
             )}
           </WindowStyle>

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+
+const useDebounce = <T>(callback: (args: T) => void, timeout = 300): ((args: T) => void) => {
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const debouncedCallback = (args: T) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      callback(args);
+    }, timeout);
+  };
+
+  return debouncedCallback;
+};
+
+export default useDebounce;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
### LikeContentItem Component

* 기존 -> 변경
<img src="https://github.com/user-attachments/assets/61f5c501-dea7-4862-ba13-ce47b812a4dd"  width="300px">
<img src="https://github.com/user-attachments/assets/0c607540-2fe4-468a-86c9-500a65c84aba" width="300px">

  * 이미지 카드 형식에서 리스트 형식으로 변경
  * 한 페이지당 컨텐츠 개수 변경 5 -> 10 
  * 하트 버튼 추가
    * 버튼 클릭시 좋아요 취소 / 재 등록 가능

### useDebounce hook
* 좋아요 버튼 적용