### PR TITLE
feat: category 기능 추가

### DIFF
--- a/apps/web/components/Category/index.module.scss
+++ b/apps/web/components/Category/index.module.scss
@@ -1,0 +1,8 @@
+@use 'styles/mixins' as m;
+
+.categoryBtn {
+  margin: 5px 10px;
+  @include m.flexboxColumn();
+  gap: 10px;
+  font-weight: var(--font-weight-bold);
+}

--- a/apps/web/components/Category/index.tsx
+++ b/apps/web/components/Category/index.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+
+import { SIMPANG_ALT } from '@/constants';
+
+import styles from './index.module.scss';
+
+interface Props {
+  currentCategory?: string;
+  category: string;
+  onClick: () => void;
+}
+
+const Category = ({ currentCategory, onClick, category }: Props) => (
+  <button className={styles.categoryBtn} onClick={() => onClick()}>
+    {category === currentCategory ? (
+      <Image src="/images/folder_open.png" width={70} height={70} alt={SIMPANG_ALT} />
+    ) : (
+      <Image src="/images/folder.png" width={70} height={70} alt={SIMPANG_ALT} />
+    )}
+    {category}
+  </button>
+);
+
+export default Category;

--- a/apps/web/constants/metadata.ts
+++ b/apps/web/constants/metadata.ts
@@ -1,6 +1,6 @@
 export const METADATA = {
   title: '심팡',
-  description: '심심할땐 심팡! 심리테스트, MBTI, 다양하게 즐겨봐!',
+  description: '심심할땐 심팡! 심리테스트, MBTI 테스트, 연애 심리, 미니 게임 다양하게 즐겨봐!',
   imageUrl: 'https://i.ibb.co/BqTn4By/og-image.jpg',
   url: new URL('https://simpang.kr'),
 };

--- a/apps/web/containers/Home/index.tsx
+++ b/apps/web/containers/Home/index.tsx
@@ -4,24 +4,30 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { Pagination, Autoplay } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { getContentsAPI } from '@/services/contents';
-import { IContent } from '@/types';
+import { getTagsAPI } from '@/services/tags';
+import { IContent, Tag } from '@/types';
 
 import styles from './index.module.scss';
 import { FloatBtnBox } from '@/components/ButtonBox/FloatBtnBox';
 import BannerItem from '@/components/Items/BannerItem';
 import ContentItem from '@/components/Items/ContentItem';
 import { Loading, RoundLoading } from '@/components/Loading';
+import WindowStyle from '@/components/WindowStyles';
 
 interface Props {
   latestContents: IContent[];
 }
 
 export default function Home({ latestContents }: Props) {
+  const [category, setCategorys] = useState<Tag>();
+
   const {
     dataList: contents,
     lastElementRef,
@@ -32,14 +38,16 @@ export default function Home({ latestContents }: Props) {
     getData: getContentsAPI,
     sort: 'desc',
     size: 10,
+    filter: { tags: category?._id },
     queryKey: 'contents',
   });
 
-  return status === 'pending' ? (
-    <Loading />
-  ) : status === 'error' ? (
-    <p>Error: {error?.message}</p>
-  ) : (
+  const { data: categorys, isLoading } = useQuery({
+    queryKey: ['tags', category],
+    queryFn: () => getTagsAPI(),
+  });
+
+  return (
     <div className={styles.wrap}>
       <div className={styles.speechBubbleWrap}>
         <p>Today&apos;s Pick ❤️</p>
@@ -63,16 +71,32 @@ export default function Home({ latestContents }: Props) {
         ))}
       </Swiper>
 
-      <div className={styles.contents}>
-        {contents &&
-          contents.map((content) => (
-            <div key={content._id} className={styles.clientArea} ref={lastElementRef}>
-              <ContentItem key={content._id} {...content} />
-            </div>
-          ))}
-        {isFetching && <RoundLoading />}
-      </div>
-
+      <WindowStyle>
+        {isLoading ? (
+          <RoundLoading />
+        ) : (
+          categorys?.map((category) => (
+            <button key={category._id} onClick={() => setCategorys(category)}>
+              {category.name}
+            </button>
+          ))
+        )}
+      </WindowStyle>
+      {status === 'pending' ? (
+        <Loading />
+      ) : status === 'error' ? (
+        <p>Error: {error?.message}</p>
+      ) : (
+        <div className={styles.contents}>
+          {contents &&
+            contents.map((content) => (
+              <div key={content._id} className={styles.clientArea} ref={lastElementRef}>
+                <ContentItem key={content._id} {...content} />
+              </div>
+            ))}
+          {isFetching && <RoundLoading />}
+        </div>
+      )}
       <FloatBtnBox />
     </div>
   );

--- a/apps/web/containers/Home/index.tsx
+++ b/apps/web/containers/Home/index.tsx
@@ -16,6 +16,7 @@ import { IContent, Tag } from '@/types';
 
 import styles from './index.module.scss';
 import { FloatBtnBox } from '@/components/ButtonBox/FloatBtnBox';
+import Category from '@/components/Category';
 import BannerItem from '@/components/Items/BannerItem';
 import ContentItem from '@/components/Items/ContentItem';
 import { Loading, RoundLoading } from '@/components/Loading';
@@ -26,7 +27,9 @@ interface Props {
 }
 
 export default function Home({ latestContents }: Props) {
-  const [category, setCategorys] = useState<Tag>();
+  const [currentCategory, setCurrentCategorys] = useState<Tag>({
+    name: '전체보기',
+  });
 
   const {
     dataList: contents,
@@ -38,14 +41,16 @@ export default function Home({ latestContents }: Props) {
     getData: getContentsAPI,
     sort: 'desc',
     size: 10,
-    filter: { tags: category?._id },
+    filter: { tags: currentCategory?._id },
     queryKey: 'contents',
   });
 
-  const { data: categorys, isLoading } = useQuery({
-    queryKey: ['tags', category],
+  const { data: categorys = [], isLoading } = useQuery({
+    queryKey: ['tags', currentCategory],
     queryFn: () => getTagsAPI(),
   });
+
+  const onClickCategoryBtn = (category: Tag) => setCurrentCategorys(category);
 
   return (
     <div className={styles.wrap}>
@@ -71,17 +76,21 @@ export default function Home({ latestContents }: Props) {
         ))}
       </Swiper>
 
-      <WindowStyle>
+      <WindowStyle title="카테고리">
         {isLoading ? (
           <RoundLoading />
         ) : (
-          categorys?.map((category) => (
-            <button key={category._id} onClick={() => setCategorys(category)}>
-              {category.name}
-            </button>
+          [{ name: '전체보기' }, ...categorys].map((category) => (
+            <Category
+              key={category.name}
+              category={category.name}
+              currentCategory={currentCategory?.name}
+              onClick={() => onClickCategoryBtn(category)}
+            />
           ))
         )}
       </WindowStyle>
+
       {status === 'pending' ? (
         <Loading />
       ) : status === 'error' ? (

--- a/apps/web/containers/Mypage/index.module.scss
+++ b/apps/web/containers/Mypage/index.module.scss
@@ -43,17 +43,6 @@
 
   .categoryContainer {
     width: 80%;
-
-    .categoryBtnBox {
-      width: 100%;
-      @include m.flexbox(around);
-
-      button {
-        @include m.flexboxColumn();
-        gap: 10px;
-        font-weight: var(--font-weight-bold);
-      }
-    }
   }
 
   .addContentBtn {

--- a/apps/web/containers/Mypage/index.tsx
+++ b/apps/web/containers/Mypage/index.tsx
@@ -13,6 +13,7 @@ import ContentList from './ContentList';
 import styles from './index.module.scss';
 import { FloatBtnBox } from '@/components/ButtonBox/FloatBtnBox';
 import Button from '@/components/Buttons/Button';
+import Category from '@/components/Category';
 import LikeContentItem from '@/components/Items/LikeContentItem';
 import ResultItem from '@/components/Items/ResultItem';
 import { Loading } from '@/components/Loading';
@@ -20,9 +21,28 @@ import ModalContent from '@/components/ModalContent';
 import ModalPortal from '@/components/ModalPortal';
 import WindowStyle from '@/components/WindowStyles';
 
+interface CategoryProps {
+  key: string;
+  name: string;
+}
+
+const categorys: CategoryProps[] = [
+  {
+    key: 'results',
+    name: '나의 결과',
+  },
+  {
+    name: '좋아요',
+    key: 'likes',
+  },
+];
+
 export default function Mypage() {
   const [showModal, setShowModal] = useState<boolean>(false);
-  const [category, setCategory] = useState<'results' | 'likes'>('results');
+  const [currentCategory, setCurrentCategorys] = useState<CategoryProps>({
+    key: 'results',
+    name: '나의 결과',
+  });
 
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -75,33 +95,23 @@ export default function Mypage() {
 
         <div className={styles.categoryContainer}>
           <WindowStyle color="yellow" title="카테고리">
-            <div className={styles.categoryBtnBox}>
-              <button onClick={() => setCategory('results')}>
-                {category === 'results' ? (
-                  <Image src="/images/folder_open.png" width={70} height={70} alt={SIMPANG_ALT} />
-                ) : (
-                  <Image src="/images/folder.png" width={70} height={70} alt={SIMPANG_ALT} />
-                )}
-                나의 결과
-              </button>
-              <button onClick={() => setCategory('likes')}>
-                {category === 'likes' ? (
-                  <Image src="/images/folder_open.png" width={70} height={70} alt={SIMPANG_ALT} />
-                ) : (
-                  <Image src="/images/folder.png" width={70} height={70} alt={SIMPANG_ALT} />
-                )}
-                좋아요
-              </button>
-            </div>
+            {categorys.map((category) => (
+              <Category
+                key={category.key}
+                category={category.name}
+                currentCategory={currentCategory?.name}
+                onClick={() => setCurrentCategorys(category)}
+              />
+            ))}
           </WindowStyle>
         </div>
 
         <div className={styles.windowWrap}>
           <WindowStyle
-            title={category === 'likes' ? '좋아요 ❤️ 목록' : '결과 ⭐️ 목록'}
-            color={category === 'likes' ? 'pink' : 'green'}
+            title={currentCategory?.key === 'likes' ? '좋아요 ❤️ 목록' : '결과 ⭐️ 목록'}
+            color={currentCategory?.key === 'likes' ? 'pink' : 'green'}
           >
-            {category === 'results' && (
+            {currentCategory?.key === 'results' && (
               <ContentList
                 queryKey={['userResult']}
                 queryFn={getUserResultsAPI}
@@ -109,7 +119,7 @@ export default function Mypage() {
                 contentIdKey="_id"
               />
             )}
-            {category === 'likes' && (
+            {currentCategory?.key === 'likes' && (
               <ContentList
                 queryKey={['likeContents']}
                 queryFn={getLikeContentsAPI}

--- a/apps/web/hooks/useInfiniteScroll.ts
+++ b/apps/web/hooks/useInfiniteScroll.ts
@@ -3,16 +3,16 @@ import { useCallback, useMemo, useRef } from 'react';
 
 import { PaginationOptions } from '@/types';
 
-const useInfiniteScroll = <T>({ getData, sort, size, queryKey }: PaginationOptions<T>) => {
+const useInfiniteScroll = <T>({ getData, sort, size, filter, queryKey }: PaginationOptions<T>) => {
   const observer = useRef<IntersectionObserver>();
 
   const fetchData = async ({ pageParam = 1 }) => {
-    const res = await getData({ page: pageParam, size, sort });
+    const res = await getData({ page: pageParam, size, sort, filter });
     return res.data;
   };
 
   const { data, error, fetchNextPage, hasNextPage, isFetching, status } = useInfiniteQuery({
-    queryKey: [queryKey, sort],
+    queryKey: [queryKey, sort, filter],
     queryFn: fetchData,
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -15,6 +15,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'http',
+        hostname: 'k.kakaocdn.net',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/apps/web/services/tags.ts
+++ b/apps/web/services/tags.ts
@@ -1,0 +1,20 @@
+import { Tag } from '@/types';
+
+import { apiBe, getHeaders } from '.';
+
+export const getTagsAPI = async (filter?: string) => {
+  const headers = getHeaders();
+  const res = await apiBe<Tag[]>(`/v1/tags?filter=${filter ? filter : ''}`, { headers });
+  return res.data;
+};
+
+export const postTagsAPI = async (data: string) => {
+  const headers = getHeaders();
+  const res = await apiBe.post<Tag>(`/v1/tags/`, { data }, { headers });
+  return res.data;
+};
+
+export const deleteTagsAPI = async (tagId: string) => {
+  const headers = getHeaders();
+  await apiBe.delete<Tag>(`/v1/tags/${tagId}`, { headers });
+};

--- a/apps/web/types/content.ts
+++ b/apps/web/types/content.ts
@@ -1,7 +1,7 @@
 export type ContentType = 'MBTI' | 'MBTI_mini';
 
 export type Tag = {
-  _id: string;
+  _id?: string;
   name: string;
 };
 

--- a/apps/web/types/content.ts
+++ b/apps/web/types/content.ts
@@ -1,5 +1,10 @@
 export type ContentType = 'MBTI' | 'MBTI_mini';
 
+export type Tag = {
+  _id: string;
+  name: string;
+};
+
 export interface IContent {
   _id: string;
   title: string;
@@ -9,6 +14,7 @@ export interface IContent {
   commentCount: number;
   likeCount: number;
   type: ContentType;
+  tags?: Tag[];
   questions?: IQuestion[];
   creator?: string;
 }

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -12,6 +12,7 @@ export interface PageParams {
   page: number;
   size: number;
   sort?: Sort;
+  filter?: object;
 }
 
 export interface GetPageData<T> {
@@ -37,6 +38,7 @@ export interface PaginationOptions<T> {
   getData: (params: PageParams) => Promise<AxiosResponse<GetPageData<T>>>;
   sort: Sort;
   size: number;
+  filter?: object;
   queryKey: string;
 }
 


### PR DESCRIPTION
tag api 활용한 category 기능 추가
- tag별 컨텐츠 목록을 화면에 표시

- Category Component 생성
  - 메인화면 및 마이페이지에 적용
  - 메인 화면
  ![image](https://github.com/user-attachments/assets/5a6a511d-f6e6-43cf-88b1-54d481c44173)
  - 마이 페이지
  ![image](https://github.com/user-attachments/assets/d29971c6-7d95-4170-93d5-da5c9bfc2aa9)
