### PR TITLE
refactor:  tag list 호출을 page에서 처리하도록 개선

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,5 @@
 import { BE_URL } from '@/constants';
-import { IContent } from '@/types';
+import { IContent, Tag } from '@/types';
 
 import Home from '@/containers/Home';
 
@@ -7,5 +7,8 @@ export default async function Page() {
   const contentData = await fetch(`${BE_URL}/api/v1/contents/random?size=5`).then(
     (res) => res.json() as Promise<IContent[]>,
   );
-  return <Home latestContents={contentData} />;
+  const categorys = await fetch(`${BE_URL}/api/v1/tags?filter=`).then(
+    (res) => res.json() as Promise<Tag[]>,
+  );
+  return <Home latestContents={contentData} categorys={categorys} />;
 }

--- a/apps/web/containers/Home/index.tsx
+++ b/apps/web/containers/Home/index.tsx
@@ -4,14 +4,12 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 
-import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Pagination, Autoplay } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { getContentsAPI } from '@/services/contents';
-import { getTagsAPI } from '@/services/tags';
 import { IContent, Tag } from '@/types';
 
 import styles from './index.module.scss';
@@ -24,10 +22,11 @@ import WindowStyle from '@/components/WindowStyles';
 
 interface Props {
   latestContents: IContent[];
+  categorys: Tag[];
 }
 
-export default function Home({ latestContents }: Props) {
-  const [currentCategory, setCurrentCategorys] = useState<Tag>({
+export default function Home({ latestContents, categorys }: Props) {
+  const [currentCategory, setCurrentCategory] = useState<Tag>({
     name: '전체보기',
   });
 
@@ -45,12 +44,7 @@ export default function Home({ latestContents }: Props) {
     queryKey: 'contents',
   });
 
-  const { data: categorys = [], isLoading } = useQuery({
-    queryKey: ['tags', currentCategory],
-    queryFn: () => getTagsAPI(),
-  });
-
-  const onClickCategoryBtn = (category: Tag) => setCurrentCategorys(category);
+  const onClickCategoryBtn = (category: Tag) => setCurrentCategory(category);
 
   return (
     <div className={styles.wrap}>
@@ -77,18 +71,14 @@ export default function Home({ latestContents }: Props) {
       </Swiper>
 
       <WindowStyle title="카테고리">
-        {isLoading ? (
-          <RoundLoading />
-        ) : (
-          [{ name: '전체보기' }, ...categorys].map((category) => (
-            <Category
-              key={category.name}
-              category={category.name}
-              currentCategory={currentCategory?.name}
-              onClick={() => onClickCategoryBtn(category)}
-            />
-          ))
-        )}
+        {[{ name: '전체보기' }, ...categorys].map((category) => (
+          <Category
+            key={category.name}
+            category={category.name}
+            currentCategory={currentCategory?.name}
+            onClick={() => onClickCategoryBtn(category)}
+          />
+        ))}
       </WindowStyle>
 
       {status === 'pending' ? (


### PR DESCRIPTION
기존 방법 사용할 경우, 클릭시 로딩 발생

- 한 번만 불러와도 됨
- 추가 업데이트 없음
- ssr 처리로 하는게 빠르고 효율적이라고 판단